### PR TITLE
Use capacity-level criticality taxonomy for sector aggregation

### DIFF
--- a/src/components/dashboard/FilterChips.tsx
+++ b/src/components/dashboard/FilterChips.tsx
@@ -86,7 +86,7 @@ export function FilterChips({
         onClick={() => toggleFilter("critical")}
       >
         <AlertCircle className="w-4 h-4 mr-1.5" />
-        {counts.critical} críticos
+        {counts.critical} rojo
       </Badge>
 
       {/* Partial filter */}
@@ -101,7 +101,7 @@ export function FilterChips({
         onClick={() => toggleFilter("partial")}
       >
         <AlertTriangle className="w-4 h-4 mr-1.5" />
-        {counts.partial} parcial
+        {counts.partial} naranja
       </Badge>
 
       {/* Capacity type filter dropdown */}

--- a/src/components/dashboard/GapRow.tsx
+++ b/src/components/dashboard/GapRow.tsx
@@ -1,8 +1,9 @@
-import { AlertCircle, AlertTriangle, Eye, Users } from "lucide-react";
+import { Eye, Users } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { GapWithDetails } from "@/services/gapService";
 import type { SignalType } from "@/types/database";
+import { NEED_STATUS_PRESENTATION, mapGapStateToNeedStatus } from "@/lib/needStatus";
 
 const SIGNAL_TYPE_COPY: Record<SignalType, string> = {
   field_report: "Reported by organizations on the ground",
@@ -41,8 +42,9 @@ function formatSignalTypes(types: SignalType[]): string {
 }
 
 export function GapRow({ gap, dominantSignalTypes, onViewSignals, onActivateActors }: GapRowProps) {
-  const isCritical = gap.state === "critical";
-  const Icon = isCritical ? AlertCircle : AlertTriangle;
+  const needStatus = gap.need_status ?? mapGapStateToNeedStatus(gap.state);
+  const presentation = NEED_STATUS_PRESENTATION[needStatus];
+  const Icon = presentation.icon;
   const capacityName = gap.capacity_type?.name || "Capacity";
   const coverageText = getCoverageText(gap);
   const signalTypeText = formatSignalTypes(dominantSignalTypes);
@@ -51,14 +53,14 @@ export function GapRow({ gap, dominantSignalTypes, onViewSignals, onActivateActo
     <div
       className={cn(
         "flex flex-col sm:flex-row sm:items-center justify-between gap-3 p-3 rounded-md border-l-4 bg-muted/30",
-        isCritical ? "border-l-gap-critical" : "border-l-warning",
+        presentation.border,
       )}
     >
       <div className="flex-1 min-w-0">
         {/* Main line: Severity + Capacity — Coverage */}
         <div className="flex items-center gap-2 flex-wrap">
-          <Icon className={cn("w-4 h-4 shrink-0", isCritical ? "text-gap-critical" : "text-warning")} />
-          <span className={cn("font-semibold", isCritical ? "text-gap-critical" : "text-warning")}>{capacityName}</span>
+          <Icon className={cn("w-4 h-4 shrink-0", presentation.text)} />
+          <span className={cn("font-semibold", presentation.text)}>{capacityName}</span>
           <span className="text-muted-foreground">—</span>
           <span className="text-foreground">{coverageText}</span>
         </div>

--- a/src/components/dashboard/SectorCardAdmin.tsx
+++ b/src/components/dashboard/SectorCardAdmin.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight, AlertCircle, AlertTriangle, Eye, Users } from "lucide-react";
+import { ChevronRight, Eye, Users } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -6,12 +6,17 @@ import { cn } from "@/lib/utils";
 import type { Sector, SignalType } from "@/types/database";
 import type { GapWithDetails } from "@/services/gapService";
 import type { SectorContext } from "@/services/mock/data";
+import { NEED_STATUS_ORDER, NEED_STATUS_PRESENTATION, mapGapStateToNeedStatus, type NeedStatus } from "@/lib/needStatus";
 
 interface SectorCardAdminProps {
   sector: Sector;
   context: SectorContext;
   gaps: GapWithDetails[];
   gapSignalTypes: Record<string, SignalType[]>;
+  sectorNeedStatus?: NeedStatus;
+  sectorNeedScore?: number;
+  sectorHighUncertainty?: boolean;
+  sectorOverrideReasons?: string[];
   onViewDetails: () => void;
   onViewSignals: (gap: GapWithDetails) => void;
   onActivateActors: (gap: GapWithDetails) => void;
@@ -24,7 +29,11 @@ export function SectorCardAdmin({
   sector,
   context,
   gaps,
-  gapSignalTypes,
+  gapSignalTypes: _gapSignalTypes,
+  sectorNeedStatus,
+  sectorNeedScore,
+  sectorHighUncertainty,
+  sectorOverrideReasons,
   onViewDetails,
   onViewSignals,
   onActivateActors,
@@ -32,25 +41,15 @@ export function SectorCardAdmin({
   onMouseEnter,
   onMouseLeave,
 }: SectorCardAdminProps) {
-  const hasCritical = gaps.some((g) => g.state === "critical");
-  const hasPartial = gaps.some((g) => g.state === "partial");
-  
-  // Determine single sector status
-  const sectorStatus = hasCritical
-    ? { label: "Crítico", color: "text-gap-critical", bg: "bg-gap-critical/20", dot: "bg-gap-critical" }
-    : hasPartial
-    ? { label: "Parcial", color: "text-warning", bg: "bg-warning/20", dot: "bg-warning" }
-    : gaps.length > 0
-    ? { label: "Activo", color: "text-yellow-500", bg: "bg-yellow-500/20", dot: "bg-yellow-500" }
-    : { label: "Contenido", color: "text-coverage", bg: "bg-coverage/20", dot: "bg-coverage" };
-
-  // Sort gaps: critical first, then partial - show max 2
-  const sortedGaps = [...gaps].sort((a, b) => {
-    if (a.state === "critical" && b.state !== "critical") return -1;
-    if (a.state !== "critical" && b.state === "critical") return 1;
-    return 0;
+  const sortedByNeed = [...gaps].sort((a, b) => {
+    const aNeed = a.need_status ?? mapGapStateToNeedStatus(a.state);
+    const bNeed = b.need_status ?? mapGapStateToNeedStatus(b.state);
+    return NEED_STATUS_ORDER.indexOf(aNeed) - NEED_STATUS_ORDER.indexOf(bNeed);
   });
-  const visibleGaps = sortedGaps.slice(0, 2);
+
+  const sectorStatus = NEED_STATUS_PRESENTATION[sectorNeedStatus ?? "WHITE"];
+
+  const visibleGaps = sortedByNeed.slice(0, 2);
   const hiddenGapsCount = gaps.length - visibleGaps.length;
 
   return (
@@ -58,7 +57,7 @@ export function SectorCardAdmin({
       id={`sector-${sector.id}`}
       className={cn(
         "border-l-4 transition-all duration-300",
-        hasCritical ? "border-l-gap-critical" : "border-l-warning",
+        sectorStatus.border,
         isHighlighted && "ring-2 ring-primary ring-offset-2 ring-offset-background"
       )}
       onMouseEnter={onMouseEnter}
@@ -69,10 +68,10 @@ export function SectorCardAdmin({
         <div className="flex items-start justify-between gap-2 mb-2">
           <div className="flex items-center gap-2 min-w-0">
             <h3 className="font-semibold text-sm truncate">{sector.canonical_name}</h3>
-            {/* Single sector status badge */}
-            <span className={cn("inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium shrink-0", sectorStatus.bg, sectorStatus.color)}>
-              <span className={cn("w-2 h-2 rounded-full", sectorStatus.dot)} />
-              {sectorStatus.label}
+            <span className={cn("inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium shrink-0", sectorStatus.bg, sectorStatus.text)}>
+              {sectorStatus.shortLabel}
+              {typeof sectorNeedScore === "number" && <span>· {sectorNeedScore.toFixed(2)}</span>}
+              {sectorHighUncertainty && <span>· ±</span>}
             </span>
           </div>
           <Button
@@ -101,21 +100,30 @@ export function SectorCardAdmin({
           </ul>
         )}
 
+        {(sectorHighUncertainty || (sectorOverrideReasons?.length ?? 0) > 0) && (
+          <p className="text-[11px] text-muted-foreground mb-2">
+            {sectorHighUncertainty ? "Alta incertidumbre" : ""}
+            {sectorHighUncertainty && (sectorOverrideReasons?.length ?? 0) > 0 ? " · " : ""}
+            {(sectorOverrideReasons?.length ?? 0) > 0 ? "Con reglas de sobre-escritura" : ""}
+          </p>
+        )}
+
         {/* Gap rows - compact inline format */}
         {visibleGaps.length > 0 && (
           <div className="space-y-1.5">
             <p className="text-xs font-medium text-muted-foreground">Faltantes:</p>
             {visibleGaps.map((gap) => {
-              const isCritical = gap.state === "critical";
-              const Icon = isCritical ? AlertCircle : AlertTriangle;
+              const gapNeed = gap.need_status ?? mapGapStateToNeedStatus(gap.state);
+              const config = NEED_STATUS_PRESENTATION[gapNeed];
+              const Icon = config.icon;
               return (
                 <div
                   key={gap.id}
                   className="flex items-center justify-between gap-2 text-xs"
                 >
                   <div className="flex items-center gap-1.5 min-w-0">
-                    <Icon className={cn("w-3 h-3 shrink-0", isCritical ? "text-gap-critical" : "text-warning")} />
-                    <span className={cn("truncate", isCritical ? "text-gap-critical" : "text-warning")}>
+                    <Icon className={cn("w-3 h-3 shrink-0", config.text)} />
+                    <span className={cn("truncate", config.text)}>
                       {gap.capacity_type?.name || "Capacity"}
                     </span>
                   </div>

--- a/src/components/dashboard/SectorGapList.tsx
+++ b/src/components/dashboard/SectorGapList.tsx
@@ -134,6 +134,10 @@ export function SectorGapList({
           context={sectorData.context}
           gaps={sectorData.gaps}
           gapSignalTypes={sectorData.gapSignalTypes}
+          sectorNeedStatus={sectorData.sector_need_status}
+          sectorNeedScore={sectorData.sector_need_score}
+          sectorHighUncertainty={sectorData.sector_high_uncertainty}
+          sectorOverrideReasons={sectorData.sector_override_reasons}
           onViewDetails={() => onViewSectorDetails(sectorData.sector.id)}
           onViewSignals={onViewSignals}
           onActivateActors={onActivateActors}

--- a/src/components/sectors/SectorDetailDrawer.tsx
+++ b/src/components/sectors/SectorDetailDrawer.tsx
@@ -233,7 +233,7 @@ export function SectorDetailDrawer({
             </section>
 
             {/* Estimated Magnitude */}
-            {context.estimatedAffected && (
+            {(sector.population_affected || context.estimatedAffected) && (
               <>
                 <Separator />
                 <section>
@@ -242,7 +242,10 @@ export function SectorDetailDrawer({
                   </h3>
                   <div className="flex items-center gap-2 text-sm">
                     <Info className="w-4 h-4 text-muted-foreground" />
-                    <span>People affected: {context.estimatedAffected} (estimated)</span>
+                    <span>
+                      People affected: {sector.population_affected?.toLocaleString() ?? context.estimatedAffected}
+                      {sector.population_affected ? "" : " (estimated)"}
+                    </span>
                   </div>
                 </section>
               </>

--- a/src/components/ui/StatusBadge.tsx
+++ b/src/components/ui/StatusBadge.tsx
@@ -5,6 +5,7 @@ export type StatusType =
   | "critical" | "warning" | "covered" | "sms" | "context" | "uncovered" | "pending"
   // Gap states (PRD-aligned)
   | "gap-critical" | "gap-partial" | "gap-active" | "gap-evaluating"
+  | "need-white" | "need-red" | "need-yellow" | "need-orange" | "need-green"
   // Deployment states (PRD-aligned)
   | "deploy-interested" | "deploy-confirmed" | "deploy-operating" | "deploy-suspended" | "deploy-finished";
 
@@ -74,6 +75,31 @@ const statusConfig: Record<StatusType, { bg: string; text: string; icon: React.E
     bg: "bg-muted",
     text: "text-muted-foreground",
     icon: Clock,
+  },
+  "need-white": {
+    bg: "bg-muted/40",
+    text: "text-muted-foreground",
+    icon: Clock,
+  },
+  "need-red": {
+    bg: "bg-gap-critical/20",
+    text: "text-gap-critical",
+    icon: XCircle,
+  },
+  "need-yellow": {
+    bg: "bg-warning/20",
+    text: "text-warning",
+    icon: AlertTriangle,
+  },
+  "need-orange": {
+    bg: "bg-orange-500/20",
+    text: "text-orange-400",
+    icon: AlertTriangle,
+  },
+  "need-green": {
+    bg: "bg-coverage/20",
+    text: "text-coverage",
+    icon: CheckCircle,
   },
   // Deployment states (PRD-aligned)
   "deploy-interested": {

--- a/src/lib/needLevelEngine.ts
+++ b/src/lib/needLevelEngine.ts
@@ -1,0 +1,612 @@
+import { NEED_STATUS_TRANSITIONS, type NeedStatus } from "@/lib/needStatus";
+
+export type RawSourceType = "institutional" | "ngo" | "social_news";
+export type SourceReliability = "Institutional" | "NGO" | "Social/News";
+
+export type ClassificationType =
+  | "SIGNAL_DEMAND_INCREASE"
+  | "SIGNAL_INSUFFICIENCY"
+  | "SIGNAL_STABILIZATION"
+  | "SIGNAL_FRAGILITY_ALERT"
+  | "SIGNAL_COVERAGE_ACTIVITY"
+  | "SIGNAL_BOTTLENECK";
+
+export interface RawInput {
+  id: string;
+  source_type: RawSourceType;
+  source_name: string;
+  timestamp: string;
+  text: string;
+  dedupe_hash: string;
+  geo_hint?: string | null;
+}
+
+export interface SignalClassification {
+  type: ClassificationType;
+  confidence: number;
+  short_quote: string;
+  note?: string;
+  coverage_kind?: "augmentation" | "baseline";
+}
+
+export interface StructuredSignal {
+  id: string;
+  raw_input_id: string;
+  sector_ref: { sector_id: string | null; confidence: number };
+  capability_ref: { capability_id: string | null; confidence: number };
+  classifications: SignalClassification[];
+  source: { reliability: SourceReliability };
+  timestamp: string;
+  unresolved: boolean;
+}
+
+export interface NeedState {
+  sector_id: string;
+  capability_id: string;
+  current_status: NeedStatus;
+  demand_score: number;
+  insufficiency_score: number;
+  stabilization_score: number;
+  fragility_score: number;
+  coverage_score: number;
+  stabilization_consecutive_windows: number;
+  last_window_id: string | null;
+  operational_requirements: string[];
+  fragility_notes: string[];
+  last_updated_at: string;
+  last_status_change_at: string | null;
+}
+
+export interface NeedEngineConfig {
+  sourceWeights: Record<SourceReliability, number>;
+  thresholds: {
+    demandEscalation: number;
+    insufficiencyEscalation: number;
+    stabilizationDowngrade: number;
+    stabilizationMinConsecutiveWindows: number;
+    fragilityReactivation: number;
+    coverageActivation: number;
+  };
+  minLlmConfidence: number;
+  rollingWindowHours: number;
+  consecutiveWindowMinutes: number;
+  evaluatorModel: string;
+  evaluatorPromptVersion: string;
+}
+
+export const defaultNeedEngineConfig: NeedEngineConfig = {
+  sourceWeights: {
+    Institutional: 1,
+    NGO: 1,
+    "Social/News": 0.4,
+  },
+  thresholds: {
+    demandEscalation: 1,
+    insufficiencyEscalation: 0.9,
+    stabilizationDowngrade: 1.8,
+    stabilizationMinConsecutiveWindows: 2,
+    fragilityReactivation: 0.9,
+    coverageActivation: 0.9,
+  },
+  minLlmConfidence: 0.65,
+  rollingWindowHours: 24,
+  consecutiveWindowMinutes: 60,
+  evaluatorModel: "unset",
+  evaluatorPromptVersion: "v1",
+};
+
+export interface EvaluatorEvidenceItem {
+  raw_input_id: string;
+  type: ClassificationType;
+  delta: number;
+  timestamp: string;
+  reliability: SourceReliability;
+  short_quote: string;
+  note?: string;
+  coverage_kind?: "augmentation" | "baseline";
+}
+
+export interface NeedEvaluatorInput {
+  sector_id: string;
+  capability_id: string;
+  previous_status: NeedStatus;
+  scores: Pick<
+    NeedState,
+    | "demand_score"
+    | "insufficiency_score"
+    | "stabilization_score"
+    | "fragility_score"
+    | "coverage_score"
+    | "stabilization_consecutive_windows"
+  >;
+  booleans: {
+    demandStrong: boolean;
+    insuffStrong: boolean;
+    stabilizationStrong: boolean;
+    fragilityAlert: boolean;
+    coverageActive: boolean;
+  };
+  window_id: string;
+  top_evidence: EvaluatorEvidenceItem[];
+  last_status_change_at: string | null;
+  allowed_transitions: NeedStatus[];
+  status_definitions: string;
+  orange_to_yellow_rule: string;
+}
+
+export interface NeedEvaluatorOutput {
+  proposed_status: NeedStatus;
+  confidence: number;
+  reasoning_summary: string;
+  contradiction_detected: boolean;
+  key_evidence: string[];
+  augmentation_commitment_detected?: boolean;
+}
+
+export interface NeedAudit {
+  id: string;
+  sector_id: string;
+  capability_id: string;
+  timestamp: string;
+  previous_status: NeedStatus;
+  proposed_status: NeedStatus;
+  final_status: NeedStatus;
+  llm_confidence: number;
+  reasoning_summary: string;
+  contradiction_detected: boolean;
+  key_evidence: string[];
+  legal_transition: boolean;
+  scores_snapshot: Pick<
+    NeedState,
+    | "demand_score"
+    | "insufficiency_score"
+    | "stabilization_score"
+    | "fragility_score"
+    | "coverage_score"
+    | "stabilization_consecutive_windows"
+  >;
+  booleans_snapshot: {
+    demandStrong: boolean;
+    insuffStrong: boolean;
+    stabilizationStrong: boolean;
+    fragilityAlert: boolean;
+    coverageActive: boolean;
+  };
+  model: string;
+  prompt_version: string;
+  config_snapshot: NeedEngineConfig;
+  illegal_transition_reason?: string;
+  guardrails_applied: string[];
+}
+
+export interface NeedsRepository {
+  findRawInputByHash(hash: string): Promise<RawInput | null>;
+  insertRawInput(raw: Omit<RawInput, "id">): Promise<RawInput>;
+  insertStructuredSignal(signal: Omit<StructuredSignal, "id">): Promise<StructuredSignal>;
+  listSignalsForNeed(params: {
+    sector_id: string;
+    capability_id: string;
+    fromInclusive: string;
+    toInclusive: string;
+  }): Promise<StructuredSignal[]>;
+  getNeedState(sector_id: string, capability_id: string): Promise<NeedState | null>;
+  upsertNeedState(state: NeedState): Promise<void>;
+  appendAudit(audit: NeedAudit): Promise<void>;
+}
+
+export interface ExtractorInput {
+  raw: RawInput;
+}
+
+export interface ExtractorOutput {
+  sector_ref: { sector_id: string | null; confidence: number };
+  capability_ref: { capability_id: string | null; confidence: number };
+  classifications: SignalClassification[];
+  source: { reliability: SourceReliability };
+  timestamp?: string;
+}
+
+export interface NeedExtractionModel {
+  extract(input: ExtractorInput): Promise<ExtractorOutput>;
+}
+
+export interface NeedEvaluatorModel {
+  evaluate(input: NeedEvaluatorInput): Promise<NeedEvaluatorOutput>;
+}
+
+export interface ProcessRawInputResult {
+  deduped: boolean;
+  raw_input: RawInput;
+  structured_signal?: StructuredSignal;
+  need_state?: NeedState;
+}
+
+function clamp01(n: number): number {
+  if (Number.isNaN(n)) return 0;
+  return Math.max(0, Math.min(1, n));
+}
+
+export function computeDedupeHash(input: {
+  text: string;
+  source_name: string;
+  timestamp: string;
+}): string {
+  const payload = `${input.text}\n${input.source_name}\n${input.timestamp}`;
+  let hash = 2166136261;
+  for (let i = 0; i < payload.length; i += 1) {
+    hash ^= payload.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return `fnv1a-${(hash >>> 0).toString(16)}`;
+}
+
+export function computeWindowId(timestamp: string, windowMinutes: number): string {
+  const ms = new Date(timestamp).getTime();
+  const windowMs = windowMinutes * 60 * 1000;
+  const bucket = Math.floor(ms / windowMs);
+  return `${bucket}`;
+}
+
+function evaluateBooleans(state: NeedState, cfg: NeedEngineConfig) {
+  return {
+    demandStrong: state.demand_score >= cfg.thresholds.demandEscalation,
+    insuffStrong: state.insufficiency_score >= cfg.thresholds.insufficiencyEscalation,
+    stabilizationStrong: state.stabilization_score >= cfg.thresholds.stabilizationDowngrade,
+    fragilityAlert: state.fragility_score >= cfg.thresholds.fragilityReactivation,
+    coverageActive: state.coverage_score >= cfg.thresholds.coverageActivation,
+  };
+}
+
+function aggregateScores(
+  signals: StructuredSignal[],
+  cfg: NeedEngineConfig,
+  nowIso: string,
+): {
+  demand_score: number;
+  insufficiency_score: number;
+  stabilization_score: number;
+  fragility_score: number;
+  coverage_score: number;
+  stabilization_consecutive_windows: number;
+  topEvidence: EvaluatorEvidenceItem[];
+  fragilityNotes: string[];
+  bottlenecks: string[];
+  augmentationDetected: boolean;
+  windowId: string;
+} {
+  const nowMs = new Date(nowIso).getTime();
+  const fromMs = nowMs - cfg.rollingWindowHours * 60 * 60 * 1000;
+
+  let demand = 0;
+  let insuff = 0;
+  let stab = 0;
+  let frag = 0;
+  let coverage = 0;
+  let augmentationDetected = false;
+
+  const stabilizationByWindow = new Map<string, number>();
+  const evidence: EvaluatorEvidenceItem[] = [];
+  const fragilityNotes: string[] = [];
+  const bottlenecks: string[] = [];
+
+  for (const signal of signals) {
+    const signalMs = new Date(signal.timestamp).getTime();
+    if (signalMs < fromMs || signalMs > nowMs) continue;
+
+    const weight = cfg.sourceWeights[signal.source.reliability];
+    const windowId = computeWindowId(signal.timestamp, cfg.consecutiveWindowMinutes);
+
+    for (const c of signal.classifications) {
+      const delta = clamp01(c.confidence) * weight;
+      evidence.push({
+        raw_input_id: signal.raw_input_id,
+        type: c.type,
+        delta,
+        timestamp: signal.timestamp,
+        reliability: signal.source.reliability,
+        short_quote: c.short_quote,
+        note: c.note,
+        coverage_kind: c.coverage_kind,
+      });
+
+      switch (c.type) {
+        case "SIGNAL_DEMAND_INCREASE":
+          demand += delta;
+          break;
+        case "SIGNAL_INSUFFICIENCY":
+          insuff += delta;
+          break;
+        case "SIGNAL_STABILIZATION": {
+          stab += delta;
+          stabilizationByWindow.set(windowId, (stabilizationByWindow.get(windowId) ?? 0) + delta);
+          break;
+        }
+        case "SIGNAL_FRAGILITY_ALERT":
+          frag += delta;
+          if (c.note) fragilityNotes.push(c.note);
+          break;
+        case "SIGNAL_COVERAGE_ACTIVITY":
+          coverage += delta;
+          if (c.coverage_kind === "augmentation") augmentationDetected = true;
+          break;
+        case "SIGNAL_BOTTLENECK":
+          if (c.note) bottlenecks.push(c.note);
+          break;
+      }
+    }
+  }
+
+  const currentWindowId = computeWindowId(nowIso, cfg.consecutiveWindowMinutes);
+  let consecutive = 0;
+  let cursor = Number(currentWindowId);
+  while (true) {
+    const value = stabilizationByWindow.get(`${cursor}`) ?? 0;
+    if (value >= cfg.thresholds.stabilizationDowngrade) {
+      consecutive += 1;
+      cursor -= 1;
+      continue;
+    }
+    break;
+  }
+
+  const topEvidence = evidence.sort((a, b) => b.delta - a.delta).slice(0, 10);
+
+  return {
+    demand_score: demand,
+    insufficiency_score: insuff,
+    stabilization_score: stab,
+    fragility_score: frag,
+    coverage_score: coverage,
+    stabilization_consecutive_windows: consecutive,
+    topEvidence,
+    fragilityNotes,
+    bottlenecks,
+    augmentationDetected,
+    windowId: currentWindowId,
+  };
+}
+
+function statusDefinitionsText() {
+  return [
+    "WHITE: monitoring/weak evidence, no strong situation identified.",
+    "RED: demand increase strong and no active credible coverage.",
+    "YELLOW: coverage active but outcomes not validated; uncertainty state.",
+    "ORANGE: coverage active and insufficiency validated.",
+    "GREEN: stabilization validated strongly and consistently, not blocked by fragility, and no dominant demand/insufficiency.",
+    "Ordering of severity: RED > ORANGE > YELLOW > GREEN > WHITE.",
+  ].join("\n");
+}
+
+export class NeedLevelEngine {
+  constructor(
+    private readonly repository: NeedsRepository,
+    private readonly extractor: NeedExtractionModel,
+    private readonly evaluator: NeedEvaluatorModel,
+    private readonly config: NeedEngineConfig = defaultNeedEngineConfig,
+  ) {}
+
+  async processRawInput(input: {
+    source_type: RawSourceType;
+    source_name: string;
+    timestamp: string;
+    text: string;
+    geo_hint?: string | null;
+    nowIso?: string;
+  }): Promise<ProcessRawInputResult> {
+    const dedupe_hash = computeDedupeHash(input);
+    const existing = await this.repository.findRawInputByHash(dedupe_hash);
+    if (existing) {
+      return { deduped: true, raw_input: existing };
+    }
+
+    const raw = await this.repository.insertRawInput({ ...input, dedupe_hash });
+    const extracted = await this.extractor.extract({ raw });
+
+    const structured = await this.repository.insertStructuredSignal({
+      raw_input_id: raw.id,
+      sector_ref: extracted.sector_ref,
+      capability_ref: extracted.capability_ref,
+      classifications: extracted.classifications,
+      source: extracted.source,
+      timestamp: extracted.timestamp ?? raw.timestamp,
+      unresolved: !extracted.sector_ref.sector_id || !extracted.capability_ref.capability_id,
+    });
+
+    if (structured.unresolved) {
+      return { deduped: false, raw_input: raw, structured_signal: structured };
+    }
+
+    const needState = await this.processStructuredSignal(structured, input.nowIso ?? input.timestamp);
+    return { deduped: false, raw_input: raw, structured_signal: structured, need_state: needState };
+  }
+
+  async processStructuredSignal(signal: StructuredSignal, nowIso: string): Promise<NeedState | undefined> {
+    const sector_id = signal.sector_ref.sector_id;
+    const capability_id = signal.capability_ref.capability_id;
+    if (!sector_id || !capability_id) return undefined;
+
+    const fromInclusive = new Date(new Date(nowIso).getTime() - this.config.rollingWindowHours * 3600 * 1000).toISOString();
+
+    const relevantSignals = await this.repository.listSignalsForNeed({
+      sector_id,
+      capability_id,
+      fromInclusive,
+      toInclusive: nowIso,
+    });
+
+    const previousState =
+      (await this.repository.getNeedState(sector_id, capability_id)) ??
+      {
+        sector_id,
+        capability_id,
+        current_status: "WHITE" as NeedStatus,
+        demand_score: 0,
+        insufficiency_score: 0,
+        stabilization_score: 0,
+        fragility_score: 0,
+        coverage_score: 0,
+        stabilization_consecutive_windows: 0,
+        last_window_id: null,
+        operational_requirements: [],
+        fragility_notes: [],
+        last_updated_at: nowIso,
+        last_status_change_at: null,
+      };
+
+    const agg = aggregateScores(relevantSignals, this.config, nowIso);
+
+    const candidateState: NeedState = {
+      ...previousState,
+      demand_score: agg.demand_score,
+      insufficiency_score: agg.insufficiency_score,
+      stabilization_score: agg.stabilization_score,
+      fragility_score: agg.fragility_score,
+      coverage_score: agg.coverage_score,
+      stabilization_consecutive_windows: agg.stabilization_consecutive_windows,
+      last_window_id: agg.windowId,
+      operational_requirements: [...previousState.operational_requirements, ...agg.bottlenecks],
+      fragility_notes: [...previousState.fragility_notes, ...agg.fragilityNotes],
+      last_updated_at: nowIso,
+    };
+
+    const booleans = evaluateBooleans(candidateState, this.config);
+    const allowed = NEED_STATUS_TRANSITIONS[previousState.current_status];
+
+    const llmResult = await this.evaluator.evaluate({
+      sector_id,
+      capability_id,
+      previous_status: previousState.current_status,
+      scores: {
+        demand_score: candidateState.demand_score,
+        insufficiency_score: candidateState.insufficiency_score,
+        stabilization_score: candidateState.stabilization_score,
+        fragility_score: candidateState.fragility_score,
+        coverage_score: candidateState.coverage_score,
+        stabilization_consecutive_windows: candidateState.stabilization_consecutive_windows,
+      },
+      booleans,
+      window_id: agg.windowId,
+      top_evidence: agg.topEvidence,
+      last_status_change_at: previousState.last_status_change_at,
+      allowed_transitions: allowed,
+      status_definitions: statusDefinitionsText(),
+      orange_to_yellow_rule:
+        "ORANGE→YELLOW only when there is credible new augmentation commitment addressing insufficiency and outcomes are not yet validated.",
+    });
+
+    let legalTransition = llmResult.proposed_status === previousState.current_status || allowed.includes(llmResult.proposed_status);
+    let proposal = legalTransition ? llmResult.proposed_status : previousState.current_status;
+    const guardrails: string[] = [];
+    let illegalTransitionReason: string | undefined;
+
+    if (!legalTransition) {
+      illegalTransitionReason = `Illegal transition ${previousState.current_status} -> ${llmResult.proposed_status}`;
+      guardrails.push("transition_legality_block");
+    }
+
+    let finalStatus = proposal;
+    let hardForced = false;
+
+    // A) RED floor
+    if (booleans.demandStrong && !booleans.coverageActive) {
+      finalStatus = "RED";
+      hardForced = true;
+      guardrails.push("A_RED_floor");
+    }
+
+    // B) ORANGE eligibility / insufficiency w/o coverage => RED
+    if (!hardForced && booleans.insuffStrong && !booleans.coverageActive) {
+      finalStatus = "RED";
+      hardForced = true;
+      guardrails.push("B_insuff_without_coverage_to_RED");
+    } else if (!hardForced && booleans.insuffStrong && booleans.coverageActive && finalStatus === "GREEN") {
+      finalStatus = "ORANGE";
+      guardrails.push("B_block_GREEN_when_insuff_and_coverage");
+    }
+
+    // C) GREEN eligibility
+    if (!hardForced && finalStatus === "GREEN") {
+      const greenEligible =
+        booleans.stabilizationStrong &&
+        candidateState.stabilization_consecutive_windows >= this.config.thresholds.stabilizationMinConsecutiveWindows &&
+        !booleans.fragilityAlert &&
+        !booleans.demandStrong &&
+        !booleans.insuffStrong;
+      if (!greenEligible) {
+        finalStatus = "YELLOW";
+        guardrails.push("C_GREEN_gate_block_to_YELLOW");
+      }
+    }
+
+    // D) Fragility blocks GREEN
+    if (!hardForced && booleans.fragilityAlert) {
+      if (finalStatus === "GREEN") {
+        finalStatus = "YELLOW";
+        guardrails.push("D_fragility_block_GREEN");
+      }
+      if (previousState.current_status === "GREEN") {
+        finalStatus = "YELLOW";
+        guardrails.push("D_force_GREEN_to_YELLOW");
+      }
+    }
+
+    // E) LLM confidence gate
+    if (!hardForced && llmResult.confidence < this.config.minLlmConfidence) {
+      finalStatus = previousState.current_status;
+      guardrails.push("E_low_llm_confidence_keep_previous");
+    }
+
+    // F) ORANGE -> YELLOW special rule
+    if (!hardForced && previousState.current_status === "ORANGE" && finalStatus === "YELLOW") {
+      const augmentationDetected = agg.augmentationDetected || llmResult.augmentation_commitment_detected === true;
+      if (!augmentationDetected) {
+        finalStatus = "ORANGE";
+        guardrails.push("F_block_ORANGE_to_YELLOW_without_augmentation");
+      } else {
+        guardrails.push("F_allow_ORANGE_to_YELLOW_with_augmentation");
+      }
+    }
+
+    const nextState: NeedState = {
+      ...candidateState,
+      current_status: finalStatus,
+      last_status_change_at:
+        finalStatus !== previousState.current_status
+          ? nowIso
+          : previousState.last_status_change_at,
+    };
+
+    await this.repository.upsertNeedState(nextState);
+
+    await this.repository.appendAudit({
+      id: crypto.randomUUID(),
+      sector_id,
+      capability_id,
+      timestamp: nowIso,
+      previous_status: previousState.current_status,
+      proposed_status: llmResult.proposed_status,
+      final_status: finalStatus,
+      llm_confidence: llmResult.confidence,
+      reasoning_summary: llmResult.reasoning_summary,
+      contradiction_detected: llmResult.contradiction_detected,
+      key_evidence: llmResult.key_evidence,
+      legal_transition: legalTransition,
+      scores_snapshot: {
+        demand_score: nextState.demand_score,
+        insufficiency_score: nextState.insufficiency_score,
+        stabilization_score: nextState.stabilization_score,
+        fragility_score: nextState.fragility_score,
+        coverage_score: nextState.coverage_score,
+        stabilization_consecutive_windows: nextState.stabilization_consecutive_windows,
+      },
+      booleans_snapshot: booleans,
+      model: this.config.evaluatorModel,
+      prompt_version: this.config.evaluatorPromptVersion,
+      config_snapshot: this.config,
+      illegal_transition_reason: illegalTransitionReason,
+      guardrails_applied: guardrails,
+    });
+
+    return nextState;
+  }
+}

--- a/src/lib/needStatus.ts
+++ b/src/lib/needStatus.ts
@@ -1,0 +1,89 @@
+import { AlertCircle, AlertTriangle, CheckCircle2, Clock3, ShieldAlert } from "lucide-react";
+import type { GapState } from "@/types/database";
+
+export type NeedStatus = "WHITE" | "RED" | "YELLOW" | "ORANGE" | "GREEN";
+
+export const NEED_STATUS_ORDER: NeedStatus[] = ["RED", "ORANGE", "YELLOW", "GREEN", "WHITE"];
+
+export const NEED_STATUS_TRANSITIONS: Record<NeedStatus, NeedStatus[]> = {
+  WHITE: ["RED", "YELLOW", "ORANGE"],
+  RED: ["YELLOW", "ORANGE"],
+  YELLOW: ["ORANGE", "GREEN", "RED", "WHITE"],
+  ORANGE: ["GREEN", "RED", "YELLOW"],
+  GREEN: ["YELLOW", "ORANGE", "RED"],
+};
+
+export interface NeedStatusPresentation {
+  label: string;
+  shortLabel: string;
+  bg: string;
+  text: string;
+  border: string;
+  dot: string;
+  statusBadge: "need-white" | "need-red" | "need-yellow" | "need-orange" | "need-green";
+  icon: typeof AlertCircle;
+}
+
+export const NEED_STATUS_PRESENTATION: Record<NeedStatus, NeedStatusPresentation> = {
+  WHITE: {
+    label: "Monitoreo",
+    shortLabel: "Blanco",
+    bg: "bg-muted/40",
+    text: "text-muted-foreground",
+    border: "border-muted",
+    dot: "bg-muted-foreground",
+    statusBadge: "need-white",
+    icon: Clock3,
+  },
+  RED: {
+    label: "Crítico sin cobertura",
+    shortLabel: "Rojo",
+    bg: "bg-gap-critical/20",
+    text: "text-gap-critical",
+    border: "border-gap-critical/50",
+    dot: "bg-gap-critical",
+    statusBadge: "need-red",
+    icon: AlertCircle,
+  },
+  ORANGE: {
+    label: "Cobertura insuficiente",
+    shortLabel: "Naranja",
+    bg: "bg-orange-500/20",
+    text: "text-orange-400",
+    border: "border-orange-500/50",
+    dot: "bg-orange-400",
+    statusBadge: "need-orange",
+    icon: ShieldAlert,
+  },
+  YELLOW: {
+    label: "Cobertura en validación",
+    shortLabel: "Amarillo",
+    bg: "bg-warning/20",
+    text: "text-warning",
+    border: "border-warning/50",
+    dot: "bg-warning",
+    statusBadge: "need-yellow",
+    icon: AlertTriangle,
+  },
+  GREEN: {
+    label: "Estabilizado",
+    shortLabel: "Verde",
+    bg: "bg-coverage/20",
+    text: "text-coverage",
+    border: "border-coverage/50",
+    dot: "bg-coverage",
+    statusBadge: "need-green",
+    icon: CheckCircle2,
+  },
+};
+
+const GAP_TO_NEED: Record<GapState, NeedStatus> = {
+  evaluating: "WHITE",
+  critical: "RED",
+  partial: "ORANGE",
+  active: "GREEN",
+};
+
+export function mapGapStateToNeedStatus(state: GapState): NeedStatus {
+  return GAP_TO_NEED[state];
+}

--- a/src/lib/sectorNeedAggregation.ts
+++ b/src/lib/sectorNeedAggregation.ts
@@ -1,0 +1,183 @@
+import type { NeedStatus } from "@/lib/needStatus";
+
+export type NeedCriticalityLevel = "life_threatening" | "high" | "medium" | "low";
+
+export interface SectorNeedInput {
+  need_id: string;
+  need_status: NeedStatus;
+  criticality_level: NeedCriticalityLevel;
+  population_weight?: number;
+  fragility_alert?: boolean;
+}
+
+export interface SectorSeverityConfig {
+  severityByStatus: Record<NeedStatus, number>;
+  criticalityWeights: Record<NeedCriticalityLevel, number>;
+  thresholds: {
+    red: number;
+    orange: number;
+    yellow: number;
+    green: number;
+  };
+  uncertaintyThreshold: number;
+  fragilityPenaltyAlpha: number;
+  criticalOverride: {
+    minStatusForLifeThreateningRed: NeedStatus;
+    highOrAboveRedCountForSectorRed: number;
+  };
+}
+
+export interface SectorNeedContribution {
+  need_id: string;
+  need_status: NeedStatus;
+  criticality_level: NeedCriticalityLevel;
+  population_weight: number;
+  effective_severity: number;
+  contribution: number;
+  fragility_alert: boolean;
+}
+
+export interface SectorSeverityResult {
+  status: NeedStatus;
+  score: number;
+  score_base: number;
+  uncertainty_share: number;
+  fragility_share: number;
+  high_uncertainty: boolean;
+  override_reasons: string[];
+  top_contributors: SectorNeedContribution[];
+}
+
+export const defaultSectorSeverityConfig: SectorSeverityConfig = {
+  severityByStatus: {
+    RED: 1,
+    ORANGE: 0.7,
+    YELLOW: 0.4,
+    GREEN: 0.1,
+    WHITE: 0,
+  },
+  criticalityWeights: {
+    life_threatening: 3,
+    high: 2,
+    medium: 1,
+    low: 0.5,
+  },
+  thresholds: {
+    red: 0.75,
+    orange: 0.55,
+    yellow: 0.3,
+    green: 0.05,
+  },
+  uncertaintyThreshold: 0.4,
+  fragilityPenaltyAlpha: 0.15,
+  criticalOverride: {
+    minStatusForLifeThreateningRed: "ORANGE",
+    highOrAboveRedCountForSectorRed: 2,
+  },
+};
+
+const statusRank: Record<NeedStatus, number> = {
+  WHITE: 0,
+  GREEN: 1,
+  YELLOW: 2,
+  ORANGE: 3,
+  RED: 4,
+};
+
+function statusFromScore(score: number, cfg: SectorSeverityConfig): NeedStatus {
+  if (score >= cfg.thresholds.red) return "RED";
+  if (score >= cfg.thresholds.orange) return "ORANGE";
+  if (score >= cfg.thresholds.yellow) return "YELLOW";
+  if (score >= cfg.thresholds.green) return "GREEN";
+  return "WHITE";
+}
+
+export function computeSectorSeverity(
+  needs: SectorNeedInput[],
+  cfg: SectorSeverityConfig = defaultSectorSeverityConfig,
+): SectorSeverityResult {
+  if (needs.length === 0) {
+    return {
+      status: "WHITE",
+      score: 0,
+      score_base: 0,
+      uncertainty_share: 0,
+      fragility_share: 0,
+      high_uncertainty: false,
+      override_reasons: [],
+      top_contributors: [],
+    };
+  }
+
+  let numerator = 0;
+  let denominator = 0;
+  let yellowWeight = 0;
+  let fragilityWeight = 0;
+  let highOrAboveRed = 0;
+  let hasLifeThreateningRed = false;
+
+  const contributions: SectorNeedContribution[] = needs.map((need) => {
+    const popWeight = need.population_weight ?? 1;
+    const criticalityWeight = cfg.criticalityWeights[need.criticality_level];
+    const weightedDenominator = criticalityWeight * popWeight;
+
+    let effectiveSeverity = cfg.severityByStatus[need.need_status];
+    if (need.fragility_alert && need.need_status === "GREEN") {
+      effectiveSeverity = Math.max(effectiveSeverity, 0.3);
+    }
+
+    const contribution = effectiveSeverity * weightedDenominator;
+
+    numerator += contribution;
+    denominator += weightedDenominator;
+
+    if (need.need_status === "YELLOW") yellowWeight += weightedDenominator;
+    if (need.fragility_alert) fragilityWeight += weightedDenominator;
+
+    if ((need.criticality_level === "high" || need.criticality_level === "life_threatening") && need.need_status === "RED") {
+      highOrAboveRed += 1;
+    }
+    if (need.criticality_level === "life_threatening" && need.need_status === "RED") {
+      hasLifeThreateningRed = true;
+    }
+
+    return {
+      need_id: need.need_id,
+      need_status: need.need_status,
+      criticality_level: need.criticality_level,
+      population_weight: popWeight,
+      effective_severity: effectiveSeverity,
+      contribution,
+      fragility_alert: need.fragility_alert === true,
+    };
+  });
+
+  const baseScore = denominator === 0 ? 0 : numerator / denominator;
+  const fragilityShare = denominator === 0 ? 0 : fragilityWeight / denominator;
+  const adjustedScore = Math.min(1, baseScore + cfg.fragilityPenaltyAlpha * fragilityShare);
+  const uncertaintyShare = denominator === 0 ? 0 : yellowWeight / denominator;
+
+  let status = statusFromScore(adjustedScore, cfg);
+  const overrideReasons: string[] = [];
+
+  if (hasLifeThreateningRed && statusRank[status] < statusRank[cfg.criticalOverride.minStatusForLifeThreateningRed]) {
+    status = cfg.criticalOverride.minStatusForLifeThreateningRed;
+    overrideReasons.push("override_life_threatening_red_floor");
+  }
+
+  if (highOrAboveRed >= cfg.criticalOverride.highOrAboveRedCountForSectorRed) {
+    status = "RED";
+    overrideReasons.push("override_multiple_high_red_to_red");
+  }
+
+  return {
+    status,
+    score: adjustedScore,
+    score_base: baseScore,
+    uncertainty_share: uncertaintyShare,
+    fragility_share: fragilityShare,
+    high_uncertainty: uncertaintyShare >= cfg.uncertaintyThreshold,
+    override_reasons: overrideReasons,
+    top_contributors: contributions.sort((a, b) => b.contribution - a.contribution).slice(0, 5),
+  };
+}

--- a/src/lib/stateTransitions.ts
+++ b/src/lib/stateTransitions.ts
@@ -1,5 +1,6 @@
 import type { GapState, DeploymentStatus, AppRole } from "@/types/database";
 import { AlertCircle, AlertTriangle, CheckCircle, Clock, Eye, Check, Activity, Pause } from "lucide-react";
+import { NEED_STATUS_PRESENTATION, mapGapStateToNeedStatus } from "@/lib/needStatus";
 
 // ============= Gap State Transitions =============
 
@@ -23,37 +24,16 @@ export interface StateConfig {
 }
 
 export function getGapStateConfig(state: GapState): StateConfig {
-  const configs: Record<GapState, StateConfig> = {
-    evaluating: {
-      bg: "bg-muted/50",
-      text: "text-muted-foreground",
-      border: "border-muted",
-      icon: Clock,
-      label: "En evaluación",
-    },
-    critical: {
-      bg: "bg-gap-critical/20",
-      text: "text-gap-critical",
-      border: "border-gap-critical/50",
-      icon: AlertCircle,
-      label: "Crítica",
-    },
-    partial: {
-      bg: "bg-warning/20",
-      text: "text-warning",
-      border: "border-warning/50",
-      icon: AlertTriangle,
-      label: "Parcial",
-    },
-    active: {
-      bg: "bg-coverage/20",
-      text: "text-coverage",
-      border: "border-coverage/50",
-      icon: CheckCircle,
-      label: "Activa",
-    },
+  const need = mapGapStateToNeedStatus(state);
+  const presentation = NEED_STATUS_PRESENTATION[need];
+
+  return {
+    bg: presentation.bg,
+    text: presentation.text,
+    border: presentation.border,
+    icon: presentation.icon,
+    label: presentation.label,
   };
-  return configs[state];
 }
 
 // ============= Deployment State Transitions =============

--- a/src/pages/EventDetail.tsx
+++ b/src/pages/EventDetail.tsx
@@ -124,6 +124,9 @@ export default function EventDetail() {
             <span>
               Iniciado: {format(new Date(event.started_at), "d MMMM yyyy, HH:mm", { locale: es })}
             </span>
+            <span>
+              Población afectada: {event.population_affected?.toLocaleString() ?? "Sin dato"}
+            </span>
             <StatusBadge
               status={event.status === "active" ? "warning" : "pending"}
               label={event.status === "active" ? "Activo" : "Cerrado"}

--- a/src/pages/Events.tsx
+++ b/src/pages/Events.tsx
@@ -164,6 +164,9 @@ function EventCard({ event, isAdmin }: { event: Event; isAdmin: boolean }) {
                 <span>
                   Started: {format(new Date(event.started_at), "d MMM yyyy")}
                 </span>
+                <span>
+                  Affected: {event.population_affected?.toLocaleString() ?? "N/A"}
+                </span>
               </div>
             </div>
           </div>

--- a/src/pages/admin/Coordination.tsx
+++ b/src/pages/admin/Coordination.tsx
@@ -33,6 +33,7 @@ export default function Coordination() {
   const [newEventName, setNewEventName] = useState("");
   const [newEventLocation, setNewEventLocation] = useState("");
   const [newEventDescription, setNewEventDescription] = useState("");
+  const [newEventPopulationAffected, setNewEventPopulationAffected] = useState("");
 
   // Form state for new sector
   const [selectedEventForSector, setSelectedEventForSector] = useState(preselectedEventId || "");
@@ -82,6 +83,7 @@ export default function Coordination() {
     try {
       const newEvent = addEvent({
         name: newEventName.trim(),
+        population_affected: newEventPopulationAffected ? Number(newEventPopulationAffected) : null,
         type: null,
         location: newEventLocation.trim() || null,
         description: newEventDescription.trim() || null,
@@ -100,6 +102,7 @@ export default function Coordination() {
       setNewEventName("");
       setNewEventLocation("");
       setNewEventDescription("");
+      setNewEventPopulationAffected("");
       setEvents([...MOCK_EVENTS]);
     } catch (error: any) {
       toast({
@@ -125,6 +128,7 @@ export default function Coordination() {
       addSector({
         event_id: selectedEventForSector,
         canonical_name: newSectorName.trim(),
+        population_affected: null,
         aliases: aliases.length > 0 ? aliases : null,
         status: "unresolved",
         source: "manual",
@@ -266,6 +270,17 @@ export default function Coordination() {
                     rows={3}
                   />
                 </div>
+                <div className="space-y-2">
+                  <Label htmlFor="eventPopulationAffected">Población afectada (evento)</Label>
+                  <Input
+                    id="eventPopulationAffected"
+                    type="number"
+                    min={0}
+                    value={newEventPopulationAffected}
+                    onChange={(e) => setNewEventPopulationAffected(e.target.value)}
+                    placeholder="Ej: 12000"
+                  />
+                </div>
                 <Button onClick={handleCreateEvent} disabled={!newEventName.trim() || isSaving}>
                   {isSaving ? "Creando..." : "Crear Evento"}
                 </Button>
@@ -301,6 +316,9 @@ export default function Coordination() {
                             <p className="font-medium">{event.name}</p>
                             <p className="text-sm text-muted-foreground">
                               {event.location || "Sin ubicación"}
+                            </p>
+                            <p className="text-xs text-muted-foreground">
+                              Población afectada: {event.population_affected?.toLocaleString() ?? "Sin dato"}
                             </p>
                           </div>
                         </div>

--- a/src/services/eventService.ts
+++ b/src/services/eventService.ts
@@ -36,6 +36,7 @@ export const eventService = {
     await simulateDelay(300);
     return addEvent({
       name: event.name || "Nuevo Evento",
+      population_affected: event.population_affected ?? null,
       type: event.type || null,
       status: "active",
       location: event.location || null,
@@ -109,6 +110,7 @@ export const eventService = {
     return addSector({
       event_id: eventId,
       canonical_name: name,
+      population_affected: null,
       aliases: aliases || null,
       status: "unresolved",
       source: "manual",

--- a/src/services/mock/data.ts
+++ b/src/services/mock/data.ts
@@ -19,23 +19,23 @@ import type {
 
 // ============== CAPACITY TYPES ==============
 export const MOCK_CAPACITY_TYPES: CapacityType[] = [
-  { id: "cap-1", name: "Evacuación y traslado", icon: "move", description: "Desplazamiento seguro de personas desde zonas de riesgo hacia lugares seguros.", created_at: new Date().toISOString() },
-  { id: "cap-2", name: "Búsqueda y rescate", icon: "search", description: "Localización y asistencia de personas atrapadas, desaparecidas o aisladas.", created_at: new Date().toISOString() },
-  { id: "cap-3", name: "Protección y seguridad básica", icon: "shield", description: "Medidas para reducir riesgos inmediatos a la integridad física de las personas.", created_at: new Date().toISOString() },
-  { id: "cap-4", name: "Atención médica de emergencia", icon: "heart-pulse", description: "Atención médica inmediata a personas lesionadas o en riesgo vital.", created_at: new Date().toISOString() },
-  { id: "cap-5", name: "Salud mental y apoyo psicosocial", icon: "brain", description: "Apoyo emocional y psicológico a personas afectadas por la emergencia.", created_at: new Date().toISOString() },
-  { id: "cap-6", name: "Agua potable", icon: "droplet", description: "Acceso a agua segura para consumo humano en cantidad suficiente.", created_at: new Date().toISOString() },
-  { id: "cap-7", name: "Saneamiento e higiene", icon: "spray-can", description: "Servicios básicos de saneamiento e higiene para prevenir riesgos sanitarios.", created_at: new Date().toISOString() },
-  { id: "cap-8", name: "Alimentación", icon: "utensils", description: "Acceso oportuno a alimentos adecuados para la población afectada.", created_at: new Date().toISOString() },
-  { id: "cap-9", name: "Alojamiento / refugio", icon: "home", description: "Soluciones temporales de alojamiento seguro y protección ambiental.", created_at: new Date().toISOString() },
-  { id: "cap-10", name: "Transporte", icon: "truck", description: "Movilización de personas, insumos y equipos necesarios para la respuesta.", created_at: new Date().toISOString() },
-  { id: "cap-11", name: "Distribución de suministros", icon: "package", description: "Entrega organizada de insumos esenciales a población o puntos de atención.", created_at: new Date().toISOString() },
-  { id: "cap-12", name: "Almacenamiento", icon: "warehouse", description: "Resguardo seguro y organizado de insumos y equipos durante la respuesta.", created_at: new Date().toISOString() },
-  { id: "cap-13", name: "Energía", icon: "zap", description: "Provisión o restablecimiento de energía eléctrica o combustible para operaciones críticas.", created_at: new Date().toISOString() },
-  { id: "cap-14", name: "Comunicaciones", icon: "radio", description: "Habilitar canales operativos de comunicación entre actores y comunidades afectadas.", created_at: new Date().toISOString() },
-  { id: "cap-15", name: "Catastro de información", icon: "clipboard-list", description: "Recopilación y síntesis de información relevante para la toma de decisiones.", created_at: new Date().toISOString() },
-  { id: "cap-16", name: "Control de incendios", icon: "flame", description: "Contención y mitigación de incendios activos que amenazan a personas o entorno.", created_at: new Date().toISOString() },
-  { id: "cap-17", name: "Gestión de materiales peligrosos", icon: "alert-triangle", description: "Manejo y mitigación de riesgos asociados a sustancias peligrosas.", created_at: new Date().toISOString() },
+  { id: "cap-1", name: "Evacuación y traslado", criticality_level: "high", icon: "move", description: "Desplazamiento seguro de personas desde zonas de riesgo hacia lugares seguros.", created_at: new Date().toISOString() },
+  { id: "cap-2", name: "Búsqueda y rescate", criticality_level: "life_threatening", icon: "search", description: "Localización y asistencia de personas atrapadas, desaparecidas o aisladas.", created_at: new Date().toISOString() },
+  { id: "cap-3", name: "Protección y seguridad básica", criticality_level: "high", icon: "shield", description: "Medidas para reducir riesgos inmediatos a la integridad física de las personas.", created_at: new Date().toISOString() },
+  { id: "cap-4", name: "Atención médica de emergencia", criticality_level: "life_threatening", icon: "heart-pulse", description: "Atención médica inmediata a personas lesionadas o en riesgo vital.", created_at: new Date().toISOString() },
+  { id: "cap-5", name: "Salud mental y apoyo psicosocial", criticality_level: "medium", icon: "brain", description: "Apoyo emocional y psicológico a personas afectadas por la emergencia.", created_at: new Date().toISOString() },
+  { id: "cap-6", name: "Agua potable", criticality_level: "life_threatening", icon: "droplet", description: "Acceso a agua segura para consumo humano en cantidad suficiente.", created_at: new Date().toISOString() },
+  { id: "cap-7", name: "Saneamiento e higiene", criticality_level: "high", icon: "spray-can", description: "Servicios básicos de saneamiento e higiene para prevenir riesgos sanitarios.", created_at: new Date().toISOString() },
+  { id: "cap-8", name: "Alimentación", criticality_level: "high", icon: "utensils", description: "Acceso oportuno a alimentos adecuados para la población afectada.", created_at: new Date().toISOString() },
+  { id: "cap-9", name: "Alojamiento / refugio", criticality_level: "high", icon: "home", description: "Soluciones temporales de alojamiento seguro y protección ambiental.", created_at: new Date().toISOString() },
+  { id: "cap-10", name: "Transporte", criticality_level: "medium", icon: "truck", description: "Movilización de personas, insumos y equipos necesarios para la respuesta.", created_at: new Date().toISOString() },
+  { id: "cap-11", name: "Distribución de suministros", criticality_level: "medium", icon: "package", description: "Entrega organizada de insumos esenciales a población o puntos de atención.", created_at: new Date().toISOString() },
+  { id: "cap-12", name: "Almacenamiento", criticality_level: "low", icon: "warehouse", description: "Resguardo seguro y organizado de insumos y equipos durante la respuesta.", created_at: new Date().toISOString() },
+  { id: "cap-13", name: "Energía", criticality_level: "high", icon: "zap", description: "Provisión o restablecimiento de energía eléctrica o combustible para operaciones críticas.", created_at: new Date().toISOString() },
+  { id: "cap-14", name: "Comunicaciones", criticality_level: "medium", icon: "radio", description: "Habilitar canales operativos de comunicación entre actores y comunidades afectadas.", created_at: new Date().toISOString() },
+  { id: "cap-15", name: "Catastro de información", criticality_level: "low", icon: "clipboard-list", description: "Recopilación y síntesis de información relevante para la toma de decisiones.", created_at: new Date().toISOString() },
+  { id: "cap-16", name: "Control de incendios", criticality_level: "life_threatening", icon: "flame", description: "Contención y mitigación de incendios activos que amenazan a personas o entorno.", created_at: new Date().toISOString() },
+  { id: "cap-17", name: "Gestión de materiales peligrosos", criticality_level: "life_threatening", icon: "alert-triangle", description: "Manejo y mitigación de riesgos asociados a sustancias peligrosas.", created_at: new Date().toISOString() },
 ];
 
 // ============== EVENTS ==============
@@ -43,6 +43,7 @@ export const MOCK_EVENTS: Event[] = [
   {
     id: "evt-mock-1",
     name: "Incendios Forestales Ñuble 2026",
+    population_affected: 6800,
     type: "incendio_forestal",
     status: "active",
     location: "Región de Ñuble",
@@ -56,6 +57,7 @@ export const MOCK_EVENTS: Event[] = [
   {
     id: "evt-mock-2",
     name: "Temporal Región Metropolitana",
+    population_affected: 2400,
     type: "temporal",
     status: "active",
     location: "Región Metropolitana",
@@ -69,6 +71,7 @@ export const MOCK_EVENTS: Event[] = [
   {
     id: "evt-mock-3",
     name: "Inundación Valdivia 2025",
+    population_affected: 1500,
     type: "inundacion",
     status: "closed",
     location: "Valdivia, Los Ríos",
@@ -88,6 +91,7 @@ export const MOCK_SECTORS: Sector[] = [
   { 
     id: "sec-1", 
     canonical_name: "San Carlos Rural", 
+    population_affected: 1900,
     status: "unresolved", 
     event_id: "evt-mock-1",
     confidence: 0.85,
@@ -101,6 +105,7 @@ export const MOCK_SECTORS: Sector[] = [
   { 
     id: "sec-2", 
     canonical_name: "Chillán Viejo Periurbano", 
+    population_affected: 1200,
     status: "tentative", 
     event_id: "evt-mock-1",
     confidence: 0.72,
@@ -114,6 +119,7 @@ export const MOCK_SECTORS: Sector[] = [
   { 
     id: "sec-3", 
     canonical_name: "Coihueco Centro", 
+    population_affected: 800,
     status: "resolved", 
     event_id: "evt-mock-1",
     confidence: 0.91,
@@ -127,6 +133,7 @@ export const MOCK_SECTORS: Sector[] = [
   { 
     id: "sec-4", 
     canonical_name: "Ñiquén Norte", 
+    population_affected: 1600,
     status: "unresolved", 
     event_id: "evt-mock-1",
     confidence: 0.78,
@@ -141,6 +148,7 @@ export const MOCK_SECTORS: Sector[] = [
   { 
     id: "sec-5", 
     canonical_name: "Maipú Sur", 
+    population_affected: 700,
     status: "unresolved", 
     event_id: "evt-mock-2",
     confidence: 0.80,
@@ -154,6 +162,7 @@ export const MOCK_SECTORS: Sector[] = [
   { 
     id: "sec-6", 
     canonical_name: "Pudahuel Poniente", 
+    population_affected: null,
     status: "tentative", 
     event_id: "evt-mock-2",
     confidence: 0.65,

--- a/src/services/needSignalService.ts
+++ b/src/services/needSignalService.ts
@@ -1,0 +1,188 @@
+import {
+  NeedLevelEngine,
+  type ExtractorInput,
+  type ExtractorOutput,
+  type NeedAudit,
+  type NeedEvaluatorInput,
+  type NeedEvaluatorOutput,
+  type NeedExtractionModel,
+  type NeedEvaluatorModel,
+  type NeedState,
+  type NeedsRepository,
+  type RawInput,
+  type StructuredSignal,
+} from "@/lib/needLevelEngine";
+import type { Signal, SignalType } from "@/types/database";
+
+class InMemoryNeedsRepository implements NeedsRepository {
+  private rawInputs = new Map<string, RawInput>();
+  private structuredSignals = new Map<string, StructuredSignal>();
+  private needStates = new Map<string, NeedState>();
+  private audits: NeedAudit[] = [];
+
+  async findRawInputByHash(hash: string): Promise<RawInput | null> {
+    return this.rawInputs.get(hash) ?? null;
+  }
+
+  async insertRawInput(raw: Omit<RawInput, "id">): Promise<RawInput> {
+    const row: RawInput = { ...raw, id: `raw-${this.rawInputs.size + 1}` };
+    this.rawInputs.set(raw.dedupe_hash, row);
+    return row;
+  }
+
+  async insertStructuredSignal(signal: Omit<StructuredSignal, "id">): Promise<StructuredSignal> {
+    const row: StructuredSignal = { ...signal, id: `structured-${this.structuredSignals.size + 1}` };
+    this.structuredSignals.set(row.id, row);
+    return row;
+  }
+
+  async listSignalsForNeed(params: { sector_id: string; capability_id: string; fromInclusive: string; toInclusive: string; }): Promise<StructuredSignal[]> {
+    const from = new Date(params.fromInclusive).getTime();
+    const to = new Date(params.toInclusive).getTime();
+
+    return [...this.structuredSignals.values()].filter((signal) => {
+      const signalTs = new Date(signal.timestamp).getTime();
+      return (
+        signal.sector_ref.sector_id === params.sector_id &&
+        signal.capability_ref.capability_id === params.capability_id &&
+        signalTs >= from &&
+        signalTs <= to
+      );
+    });
+  }
+
+  async getNeedState(sector_id: string, capability_id: string): Promise<NeedState | null> {
+    return this.needStates.get(`${sector_id}:${capability_id}`) ?? null;
+  }
+
+  async upsertNeedState(state: NeedState): Promise<void> {
+    this.needStates.set(`${state.sector_id}:${state.capability_id}`, state);
+  }
+
+  async appendAudit(audit: NeedAudit): Promise<void> {
+    this.audits.push(audit);
+  }
+}
+
+class LegacySignalExtractor implements NeedExtractionModel {
+  async extract(input: ExtractorInput): Promise<ExtractorOutput> {
+    const payload = JSON.parse(input.raw.text) as {
+      event_id: string;
+      sector_id: string | null;
+      capability_id: string | null;
+      signal_type: SignalType;
+      content: string;
+      confidence: number;
+      source: string;
+      created_at: string;
+    };
+
+    const type = mapSignalType(payload.signal_type, payload.content);
+
+    return {
+      sector_ref: { sector_id: payload.sector_id, confidence: 1 },
+      capability_ref: { capability_id: payload.capability_id, confidence: payload.confidence },
+      source: {
+        reliability:
+          payload.signal_type === "official" || payload.signal_type === "actor_report"
+            ? "Institutional"
+            : payload.signal_type === "field_report"
+            ? "NGO"
+            : "Social/News",
+      },
+      timestamp: payload.created_at,
+      classifications: [
+        {
+          type,
+          confidence: payload.confidence,
+          short_quote: payload.content.slice(0, 200),
+          coverage_kind: /refuerzo|reinforcement|augment/i.test(payload.content) ? "augmentation" : "baseline",
+        },
+      ],
+    };
+  }
+}
+
+class RuleBasedNeedEvaluator implements NeedEvaluatorModel {
+  async evaluate(input: NeedEvaluatorInput): Promise<NeedEvaluatorOutput> {
+    const { demandStrong, insuffStrong, stabilizationStrong, fragilityAlert, coverageActive } = input.booleans;
+
+    let proposed_status = input.previous_status;
+
+    if (demandStrong && !coverageActive) {
+      proposed_status = "RED";
+    } else if (insuffStrong && coverageActive) {
+      proposed_status = "ORANGE";
+    } else if (stabilizationStrong && !fragilityAlert && !demandStrong && !insuffStrong) {
+      proposed_status = "GREEN";
+    } else if (coverageActive) {
+      proposed_status = "YELLOW";
+    } else {
+      proposed_status = "WHITE";
+    }
+
+    return {
+      proposed_status,
+      confidence: 0.8,
+      reasoning_summary: "Rule-based evaluator proposal from weighted evidence.",
+      contradiction_detected: demandStrong && stabilizationStrong,
+      key_evidence: input.top_evidence.slice(0, 3).map((e) => e.raw_input_id),
+      augmentation_commitment_detected: input.top_evidence.some((e) => e.coverage_kind === "augmentation"),
+    };
+  }
+}
+
+function mapSignalType(signalType: SignalType, content: string) {
+  if (/fragil|riesgo|colapso|inestable/i.test(content)) {
+    return "SIGNAL_FRAGILITY_ALERT" as const;
+  }
+  if (/no alcanza|insuficiente|saturado|sin/i.test(content)) {
+    return "SIGNAL_INSUFFICIENCY" as const;
+  }
+  if (/operando|estable|normaliz|restablec/i.test(content)) {
+    return "SIGNAL_STABILIZATION" as const;
+  }
+  if (/llega|despacho|en camino|refuerzo/i.test(content)) {
+    return "SIGNAL_COVERAGE_ACTIVITY" as const;
+  }
+  if (signalType === "sms" || signalType === "social" || signalType === "news") {
+    return "SIGNAL_DEMAND_INCREASE" as const;
+  }
+  return "SIGNAL_INSUFFICIENCY" as const;
+}
+
+const repository = new InMemoryNeedsRepository();
+const extractor = new LegacySignalExtractor();
+const evaluator = new RuleBasedNeedEvaluator();
+const engine = new NeedLevelEngine(repository, extractor, evaluator);
+
+export const needSignalService = {
+  async evaluateGapNeed(params: {
+    eventId: string;
+    sectorId: string;
+    capabilityId: string;
+    signals: Signal[];
+    nowIso?: string;
+  }): Promise<NeedState | null> {
+    const nowIso = params.nowIso ?? new Date().toISOString();
+
+    for (const signal of params.signals) {
+      await engine.processRawInput({
+        source_type: signal.signal_type === "official" ? "institutional" : signal.signal_type === "field_report" ? "ngo" : "social_news",
+        source_name: signal.source,
+        timestamp: signal.created_at,
+        text: JSON.stringify({
+          ...signal,
+          capability_id: params.capabilityId,
+          sector_id: params.sectorId,
+          event_id: params.eventId,
+        }),
+        geo_hint: params.sectorId,
+        nowIso,
+      });
+    }
+
+    const state = await repository.getNeedState(params.sectorId, params.capabilityId);
+    return state;
+  },
+};

--- a/src/test/needLevelEngine.test.ts
+++ b/src/test/needLevelEngine.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "vitest";
+import {
+  type ExtractorInput,
+  type ExtractorOutput,
+  NeedLevelEngine,
+  type NeedEvaluatorInput,
+  type NeedEvaluatorOutput,
+  type NeedState,
+  type NeedsRepository,
+  defaultNeedEngineConfig,
+} from "@/lib/needLevelEngine";
+
+class InMemoryRepo implements NeedsRepository {
+  raw: any[] = [];
+  signals: any[] = [];
+  needs = new Map<string, NeedState>();
+  audits: any[] = [];
+
+  private key(s: string, c: string) {
+    return `${s}::${c}`;
+  }
+
+  async findRawInputByHash(hash: string) {
+    return this.raw.find((r) => r.dedupe_hash === hash) ?? null;
+  }
+
+  async insertRawInput(raw: any) {
+    const item = { id: `raw-${this.raw.length + 1}`, ...raw };
+    this.raw.push(item);
+    return item;
+  }
+
+  async insertStructuredSignal(signal: any) {
+    const item = { id: `sig-${this.signals.length + 1}`, ...signal };
+    this.signals.push(item);
+    return item;
+  }
+
+  async listSignalsForNeed(params: { sector_id: string; capability_id: string; fromInclusive: string; toInclusive: string; }) {
+    return this.signals.filter(
+      (s) =>
+        s.sector_ref.sector_id === params.sector_id &&
+        s.capability_ref.capability_id === params.capability_id &&
+        s.timestamp >= params.fromInclusive &&
+        s.timestamp <= params.toInclusive,
+    );
+  }
+
+  async getNeedState(sector_id: string, capability_id: string) {
+    return this.needs.get(this.key(sector_id, capability_id)) ?? null;
+  }
+
+  async upsertNeedState(state: NeedState) {
+    this.needs.set(this.key(state.sector_id, state.capability_id), state);
+  }
+
+  async appendAudit(audit: any) {
+    this.audits.push(audit);
+  }
+}
+
+class StaticExtractor {
+  constructor(private out: ExtractorOutput) {}
+  async extract(_: ExtractorInput) {
+    return this.out;
+  }
+}
+
+class StaticEvaluator {
+  constructor(private out: NeedEvaluatorOutput) {}
+  async evaluate(_: NeedEvaluatorInput) {
+    return this.out;
+  }
+}
+
+const now = "2026-02-16T10:00:00.000Z";
+const baseExtractor: ExtractorOutput = {
+  sector_ref: { sector_id: "sec-1", confidence: 0.95 },
+  capability_ref: { capability_id: "cap-1", confidence: 0.9 },
+  source: { reliability: "Institutional" },
+  classifications: [
+    {
+      type: "SIGNAL_DEMAND_INCREASE",
+      confidence: 1,
+      short_quote: "Demand sharply increased",
+    },
+  ],
+  timestamp: now,
+};
+
+const baseEval: NeedEvaluatorOutput = {
+  proposed_status: "YELLOW",
+  confidence: 0.9,
+  reasoning_summary: "coverage uncertain",
+  contradiction_detected: false,
+  key_evidence: ["raw-1"],
+};
+
+describe("NeedLevelEngine", () => {
+  it("deduplicates raw input by dedupe_hash", async () => {
+    const repo = new InMemoryRepo();
+    const engine = new NeedLevelEngine(repo, new StaticExtractor(baseExtractor), new StaticEvaluator(baseEval));
+
+    const payload = {
+      source_type: "institutional" as const,
+      source_name: "agency",
+      timestamp: now,
+      text: "same text",
+    };
+
+    const first = await engine.processRawInput(payload);
+    const second = await engine.processRawInput(payload);
+
+    expect(first.deduped).toBe(false);
+    expect(second.deduped).toBe(true);
+    expect(repo.raw).toHaveLength(1);
+  });
+
+  it("applies RED floor when demand is strong and coverage inactive", async () => {
+    const repo = new InMemoryRepo();
+    const engine = new NeedLevelEngine(repo, new StaticExtractor(baseExtractor), new StaticEvaluator(baseEval));
+
+    await engine.processRawInput({
+      source_type: "institutional",
+      source_name: "agency",
+      timestamp: now,
+      text: "new incident",
+    });
+
+    const state = await repo.getNeedState("sec-1", "cap-1");
+    expect(state?.current_status).toBe("RED");
+  });
+
+  it("blocks GREEN when consecutive stabilization windows are insufficient", async () => {
+    const repo = new InMemoryRepo();
+    const extractor = new StaticExtractor({
+      ...baseExtractor,
+      classifications: [{ type: "SIGNAL_STABILIZATION", confidence: 1, short_quote: "improved" }],
+    });
+    const evaluator = new StaticEvaluator({ ...baseEval, proposed_status: "GREEN" });
+    const engine = new NeedLevelEngine(repo, extractor, evaluator);
+
+    await engine.processRawInput({ source_type: "ngo", source_name: "ngo", timestamp: now, text: "one window" });
+    const state = await repo.getNeedState("sec-1", "cap-1");
+    expect(state?.current_status).toBe("YELLOW");
+  });
+
+  it("forces GREEN to YELLOW when fragility alert is active", async () => {
+    const repo = new InMemoryRepo();
+    repo.needs.set("sec-1::cap-1", {
+      sector_id: "sec-1",
+      capability_id: "cap-1",
+      current_status: "GREEN",
+      demand_score: 0,
+      insufficiency_score: 0,
+      stabilization_score: 0,
+      fragility_score: 0,
+      coverage_score: 0,
+      stabilization_consecutive_windows: 2,
+      last_window_id: null,
+      operational_requirements: [],
+      fragility_notes: [],
+      last_updated_at: now,
+      last_status_change_at: now,
+    });
+
+    const extractor = new StaticExtractor({
+      ...baseExtractor,
+      classifications: [{ type: "SIGNAL_FRAGILITY_ALERT", confidence: 1, short_quote: "new risk" }],
+    });
+
+    const engine = new NeedLevelEngine(repo, extractor, new StaticEvaluator({ ...baseEval, proposed_status: "GREEN" }));
+
+    await engine.processRawInput({ source_type: "social_news", source_name: "news", timestamp: now, text: "risk" });
+    const state = await repo.getNeedState("sec-1", "cap-1");
+    expect(state?.current_status).toBe("YELLOW");
+  });
+
+  it("blocks ORANGE->YELLOW without augmentation evidence", async () => {
+    const repo = new InMemoryRepo();
+    repo.needs.set("sec-1::cap-1", {
+      sector_id: "sec-1",
+      capability_id: "cap-1",
+      current_status: "ORANGE",
+      demand_score: 0,
+      insufficiency_score: 0,
+      stabilization_score: 0,
+      fragility_score: 0,
+      coverage_score: 0,
+      stabilization_consecutive_windows: 0,
+      last_window_id: null,
+      operational_requirements: [],
+      fragility_notes: [],
+      last_updated_at: now,
+      last_status_change_at: now,
+    });
+
+    const extractor = new StaticExtractor({
+      ...baseExtractor,
+      classifications: [{ type: "SIGNAL_COVERAGE_ACTIVITY", confidence: 1, short_quote: "coverage", coverage_kind: "baseline" }],
+    });
+
+    const engine = new NeedLevelEngine(repo, extractor, new StaticEvaluator({ ...baseEval, proposed_status: "YELLOW" }));
+
+    await engine.processRawInput({ source_type: "ngo", source_name: "ngo", timestamp: now, text: "baseline only" });
+    const state = await repo.getNeedState("sec-1", "cap-1");
+    expect(state?.current_status).toBe("ORANGE");
+  });
+
+  it("keeps previous status when llm confidence is below threshold", async () => {
+    const repo = new InMemoryRepo();
+    const cfg = { ...defaultNeedEngineConfig, minLlmConfidence: 0.9 };
+    const engine = new NeedLevelEngine(
+      repo,
+      new StaticExtractor({
+        ...baseExtractor,
+        classifications: [{ type: "SIGNAL_COVERAGE_ACTIVITY", confidence: 1, short_quote: "coverage", coverage_kind: "augmentation" }],
+      }),
+      new StaticEvaluator({ ...baseEval, proposed_status: "YELLOW", confidence: 0.5 }),
+      cfg,
+    );
+
+    await engine.processRawInput({ source_type: "ngo", source_name: "ngo", timestamp: now, text: "low llm" });
+    const state = await repo.getNeedState("sec-1", "cap-1");
+    expect(state?.current_status).toBe("WHITE");
+  });
+});

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -41,6 +41,7 @@ export interface Profile {
 export interface Event {
   id: string;
   name: string;
+  population_affected: number | null;
   type: string | null;
   description: string | null;
   location: string | null;
@@ -55,6 +56,7 @@ export interface Event {
 export interface CapacityType {
   id: string;
   name: string;
+  criticality_level: 'life_threatening' | 'high' | 'medium' | 'low';
   description: string | null;
   icon: string | null;
   created_at: string;
@@ -64,6 +66,7 @@ export interface Sector {
   id: string;
   event_id: string;
   canonical_name: string;
+  population_affected: number | null;
   aliases: string[] | null;
   latitude: number | null;
   longitude: number | null;


### PR DESCRIPTION
### Motivation

- Separate the intrinsic criticality of a capability (how life‑threatening it is) from the current need/status color so sector scores combine two distinct dimensions. 
- Stop inferring criticality from `gap.state` (which conflated status and criticality) and enable stable, explainable sector aggregation and UI surfacing.

### Description

- Added explicit `criticality_level` to `CapacityType` and populated the mock catalog with a base taxonomy (`life_threatening | high | medium | low`) in `src/types/database.ts` and `src/services/mock/data.ts`.
- Replaced the previous gap-state inference with a capacity-driven lookup in `src/services/gapService.ts` by changing `inferNeedCriticality` to read `gap.capacity_type?.criticality_level` and wiring `computeSectorSeverity` to compute `sector_need_status`, `sector_need_score`, `sector_high_uncertainty` and `sector_override_reasons`.
- Introduced a sector aggregation module `src/lib/sectorNeedAggregation.ts` that weights need status by configurable severity and capacity criticality, applies fragility/uncertainty guardrails and returns explainability metadata.
- Added a small need/status stack and rule engine: `src/lib/needStatus.ts` (need presentation + mappings), `src/lib/needLevelEngine.ts` (signal-driven need evaluator), and `src/services/needSignalService.ts` (in-memory repo + simple extractor/evaluator) to evaluate gap need states from signals; updated UI components to use the new presentation and surface scores/population (components under `src/components/*`, and pages `src/pages/*`).
- Added a test scaffold `src/test/needLevelEngine.test.ts` exercising major guardrails and transitions.

### Testing

- Attempted `npm test -- --runInBand`, but the run failed in this environment because `vitest` is not installed (`vitest: not found`).
- Attempted a Playwright screenshot to validate UI, but it failed with `ERR_EMPTY_RESPONSE` because no dev server was running at `127.0.0.1:5173` in this environment.
- The new unit tests were added (`src/test/needLevelEngine.test.ts`) but could not be executed here; they should run in CI or a developer environment with `vitest`/`vite` available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995963f89c48326bfa7ef1297419477)